### PR TITLE
Fix allow next page after completion of lost hokie bird

### DIFF
--- a/frontend/src/components/HokieBirdMap.tsx
+++ b/frontend/src/components/HokieBirdMap.tsx
@@ -68,6 +68,7 @@ export function HokieBirdMap({
         setMessage("You did it!");
         setCurrentImage(props.images[procedures.length]);
         navigate(`/book/${props.bookID}/${props.pageNum + 1}`);
+        setAllowNext(true);
       }
     }
   }


### PR DESCRIPTION
This pull request fixes the issue where the next page was not allowed after completing the lost hokie bird. The issue was resolved by adding the necessary code to allow the next page.