### PR TITLE
book grades not shown and category above books shown instead

### DIFF
--- a/frontend/src/components/ActivityBookList.tsx
+++ b/frontend/src/components/ActivityBookList.tsx
@@ -13,8 +13,7 @@ function BookPreview({ BookData }: { BookData: Book }) {
             alt="Book Background"
             className="absolute"
           />
-          <div className="relative top-12 left-4 w-52 h-64 flex-col flex items-center p-2 text-center">
-            <p className="mt-1 mb-2 text-sm text-end text-black">{` Grades: ${BookData.gradeRange}`}</p>
+          <div className="relative top-16 left-4 w-52 h-64 flex-col flex items-center p-2 text-center">
             <img
               src={BookData.cover ? BookData.cover : BookData.pages[0].image}
               width={125}

--- a/frontend/src/pages/BookCategoryPage.tsx
+++ b/frontend/src/pages/BookCategoryPage.tsx
@@ -4,6 +4,7 @@ import ActivityBookList from "../components/ActivityBookList";
 import Navbar from "../components/Navbar";
 import Footer from "../components/Footer";
 import Background from "../components/Background";
+import { toTitleCase } from "../util/toTitleCase";
 
 export default function BookCategoryPage() {
   // try to get the category from the params
@@ -28,8 +29,11 @@ export default function BookCategoryPage() {
             height={150}
             className="mx-auto"
           />
-          <div className="card p-2 mb-2 max-w-lg text-center">
+          <div className="p-4 max-w-lg text-center">
             <h1 className="text-2xl font-bold">Pick a book!</h1>
+            <div className="bg-primary-green border-2 border-gray-300 rounded-full text-white p-2 text-xl font-bold">
+              {toTitleCase(category)}
+            </div>
           </div>
         </div>
         <ActivityBookList category={category} />

--- a/frontend/src/util/toTitleCase.ts
+++ b/frontend/src/util/toTitleCase.ts
@@ -1,0 +1,8 @@
+export function toTitleCase(str: string): string {
+    return str.replace(
+        /\w\S*/g,
+        function (txt) {
+            return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+        }
+    );
+}

--- a/frontend/src/util/toTitleCase.ts
+++ b/frontend/src/util/toTitleCase.ts
@@ -1,8 +1,5 @@
 export function toTitleCase(str: string): string {
-    return str.replace(
-        /\w\S*/g,
-        function (txt) {
-            return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
-        }
-    );
+  return str.replace(/\w\S*/g, function (txt) {
+    return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+  });
 }


### PR DESCRIPTION
Fixes: #256

removes all book grade ranges and adds a label of the category (beginner intermediate hard ) above the books﻿
