### PR TITLE
removing comparison from legacy tools. 

### DIFF
--- a/frontend/src/pages/BookEditor.tsx
+++ b/frontend/src/pages/BookEditor.tsx
@@ -744,7 +744,6 @@ function ImageTypeEditor({
     "ClothingActivity",
     "BookRushHour",
     "CodeStepFlowchart",
-    "Comparison",
   ]);
 
   // Filter options: always show non-legacy tools.


### PR DESCRIPTION
Comparison component is currently not visible from the drop-down in the book editor because it was accidentally placed as a legacy tool. However, comparison shouldn't be a legacy tool because it is reusable. 