### PR TITLE
Book Editor refactor - adding slider in middle of book editor so the book content and editor windows can be resized

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,6 +28,7 @@
         "react-router-dom": "^6.22.0",
         "react-scripts": "5.0.1",
         "react-simple-code-editor": "^0.13.1",
+        "react-split": "^2.0.14",
         "react-use": "^17.5.0",
         "reagraph": "^4.15.10",
         "typescript": "^4.9.5",
@@ -17419,6 +17420,19 @@
         "react-dom": "*"
       }
     },
+    "node_modules/react-split": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/react-split/-/react-split-2.0.14.tgz",
+      "integrity": "sha512-bKWydgMgaKTg/2JGQnaJPg51T6dmumTWZppFgEbbY0Fbme0F5TuatAScCLaqommbGQQf/ZT1zaejuPDriscISA==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.5.7",
+        "split.js": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-syntax-highlighter": {
       "version": "15.5.0",
       "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.5.0.tgz",
@@ -18668,6 +18682,12 @@
         "readable-stream": "^3.0.6",
         "wbuf": "^1.7.3"
       }
+    },
+    "node_modules/split.js": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/split.js/-/split.js-1.6.5.tgz",
+      "integrity": "sha512-mPTnGCiS/RiuTNsVhCm9De9cCAUsrNFFviRbADdKiiV+Kk8HKp/0fWu7Kr8pi3/yBmsqLFHuXGT9UUZ+CNLwFw==",
+      "license": "MIT"
     },
     "node_modules/split2": {
       "version": "3.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "react-router-dom": "^6.22.0",
     "react-scripts": "5.0.1",
     "react-simple-code-editor": "^0.13.1",
+    "react-split": "^2.0.14",
     "react-use": "^17.5.0",
     "reagraph": "^4.15.10",
     "typescript": "^4.9.5",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -112,6 +112,17 @@ pre {
   border-radius: 7px;
 }
 
+/* Book editor middle adjuster */
+.gutter {
+  background-color: #e5e7eb;
+  cursor: col-resize;
+}
+
+.gutter-horizontal {
+  height: 100%;
+  width: 10px;
+}
+
 ::-webkit-scrollbar-corner {
   background: rgba(0, 0, 0, 0.5);
 }

--- a/frontend/src/pages/BookEditor.tsx
+++ b/frontend/src/pages/BookEditor.tsx
@@ -8,6 +8,7 @@ import { ErrorBoundary } from "react-error-boundary";
 import { BookPreview } from "../components/ActivityBookList";
 import Editor from "@monaco-editor/react";
 import { useTheme } from "../context/ThemeContext";
+import Split from "react-split";
 
 interface PropsFormProps {
   tempProps: string;
@@ -925,73 +926,84 @@ function PageEditor({
 
   return (
     <div className="flex w-full h-full">
-      <div
-        className={`${middleSectionClass} bg-white rounded-lg overflow-hidden`}
+      <Split
+        sizes={[70, 30]}
+        minSize={200}
+        expandToMin={false}
+        gutterSize={10}
+        gutterAlign="center"
+        snapOffset={30}
+        dragInterval={1}
+        direction="horizontal"
+        className="flex w-full h-full"
       >
-        <div className="w-full h-full p-4">
-          <div className="h-full w-full shadow-2xl rounded-2xl bg-white border flex">
-            <div className="w-8/12 p-4 border-r border-gray-200 flex justify-center items-center overflow-hidden">
-              <div className="w-full h-full overflow-hidden rounded-lg flex justify-center items-center">
-                <div
-                  style={{
-                    maxWidth: "100%",
-                    maxHeight: "100%",
-                    width: "auto",
-                    height: "auto",
-                    transform: `scale(${bookImageScale})`,
-                    transformOrigin: "center",
-                  }}
-                >
-                  <ErrorBoundary
-                    fallback={
-                      <div className="text-red-500 text-lg">
-                        Error, try adjusting the props
-                      </div>
-                    }
+        <div
+          className={`${middleSectionClass} bg-white rounded-lg overflow-hidden`}
+        >
+          <div className="w-full h-full p-4">
+            <div className="h-full w-full shadow-2xl rounded-2xl bg-white border flex">
+              <div className="w-8/12 p-4 border-r border-gray-200 flex justify-center items-center overflow-hidden">
+                <div className="w-full h-full overflow-hidden rounded-lg flex justify-center items-center">
+                  <div
+                    style={{
+                      maxWidth: "100%",
+                      maxHeight: "100%",
+                      width: "auto",
+                      height: "auto",
+                      transform: `scale(${bookImageScale})`,
+                      transformOrigin: "center",
+                    }}
                   >
-                    <BookImage
-                      key={`${tempImage}-${tempProps}-${page.pageNumber}`}
-                      image={tempImage}
-                      page={{
-                        ...page,
-                        image: tempImage,
-                        props: JSON.parse(tempProps),
-                      }}
-                      setAllowNext={() => {}}
-                    />
-                  </ErrorBoundary>
+                    <ErrorBoundary
+                      fallback={
+                        <div className="text-red-500 text-lg">
+                          Error, try adjusting the props
+                        </div>
+                      }
+                    >
+                      <BookImage
+                        key={`${tempImage}-${tempProps}-${page.pageNumber}`}
+                        image={tempImage}
+                        page={{
+                          ...page,
+                          image: tempImage,
+                          props: JSON.parse(tempProps),
+                        }}
+                        setAllowNext={() => {}}
+                      />
+                    </ErrorBoundary>
+                  </div>
                 </div>
               </div>
-            </div>
 
-            <div className="w-4/12 p-4 overflow-y-auto">
-              <div className="h-full overflow-hidden">
-                {page.content && page.content.length > 0 && (
-                  <BookContentEditor
-                    content={page.content}
-                    setContent={setContent}
-                  />
-                )}
+              <div className="w-4/12 p-4 overflow-y-auto">
+                <div className="h-full overflow-hidden">
+                  {page.content && page.content.length > 0 && (
+                    <BookContentEditor
+                      content={page.content}
+                      setContent={setContent}
+                    />
+                  )}
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-
-      <div
-        className={`${activityEditorClass} p-2 transition-all duration-300 ease-in-out min-w-0 max-w-full h-full overflow-hidden`}
-      >
-        <div className="h-full w-full shadow-2xl rounded-2xl bg-white border overflow-hidden flex flex-col">
-          <BookImageEditor
-            tempImage={tempImage}
-            setTempImage={setTempImage}
-            tempProps={tempProps}
-            setTempProps={setTempProps}
-            page={page}
-            setPage={setPage}
-          />
+        <div
+          className={`${activityEditorClass} p-2 transition-all duration-300 ease-in-out min-w-0 max-w-full h-full overflow-hidden`}
+        >
+          <div className="h-full w-full shadow-2xl rounded-2xl bg-white border overflow-hidden flex flex-col">
+            <BookImageEditor
+              tempImage={tempImage}
+              setTempImage={setTempImage}
+              tempProps={tempProps}
+              setTempProps={setTempProps}
+              page={page}
+              setPage={setPage}
+            />
+          </div>
         </div>
-      </div>
+      </Split>
     </div>
   );
 }


### PR DESCRIPTION
### What was changed
A slider was added to the middle of the page that allows the user to resize the windows on the page. Screenshots showing the difference are attached below.

Before, with each part of the page as a fixed size: 
<img width="959" height="464" alt="image" src="https://github.com/user-attachments/assets/d38678f3-2d91-48f7-bd4a-9f5bbd8d937f" />


After, with each part of the page having dynamic sizing:
<img width="959" height="461" alt="image" src="https://github.com/user-attachments/assets/a1536bfa-a4d8-4e55-bb88-24d695dd2ee3" />
<img width="959" height="457" alt="image" src="https://github.com/user-attachments/assets/dce2cb39-28a6-4298-8a46-7c3ed8bd4b38" />

